### PR TITLE
NullPointerException fix

### DIFF
--- a/src/com/redomar/game/Game.java
+++ b/src/com/redomar/game/Game.java
@@ -57,7 +57,6 @@ public class Game extends Canvas implements Runnable {
 	private static int steps;
 	private static boolean devMode;
 	private static boolean closingMode;
-	private static boolean isAzertyCountry;
 	
 	private static JFrame frame;
 
@@ -307,7 +306,10 @@ public class Game extends Canvas implements Runnable {
 			print.print("Teleported into new world", PrintTypes.GAME);
 			if (getMap() == 1) {
 				setMap("/levels/water_level.png");
-				getLevel().removeEntity(getDummy()); setNpc(false);
+				if(getDummy()!=null){ // Gave nullPointerException(); upon entering new world.
+					getLevel().removeEntity(getDummy()); 
+					setNpc(false);
+				}
 				getLevel().removeEntity(getVendor());
 				setMap(2);
 			} else if (getMap() == 2) {


### PR DESCRIPTION
Added != null when player walks throughthe teleporter.
I'm not 100% sure on the objective on the game, maybe you want people not to be able to enter the second level yet? Or before finishing something. Either way, this avoids the crash. Could you explain to me the aim of the game? What needs to be done before they can step through the portal.

Kinds regards
